### PR TITLE
fix: return error when carbon intensity value is zero to trigger eco-mode-off

### DIFF
--- a/controllers/carbonawarekedascaler_controller_test.go
+++ b/controllers/carbonawarekedascaler_controller_test.go
@@ -628,6 +628,26 @@ var _ = Describe("scenarios for the carbon aware KEDA Scaler", func() {
 			})
 		})
 
+		When("the forecasted carbon intensity value is zero", func() {
+			It("should return an error so the caller falls back to eco-mode-off", func() {
+				var maxReplicaConfig *int32 = new(int32)
+				*maxReplicaConfig = 10
+				forecast := &CarbonForecast{
+					Timestamp: time.Now().UTC(),
+					Value:     0,
+					Duration:  5,
+				}
+				maxReplicas, err := getMaxReplicas(forecast, []carbonawarev1alpha1.CarbonIntensityConfig{
+					{
+						MaxReplicas:              maxReplicaConfig,
+						CarbonIntensityThreshold: 100,
+					},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(maxReplicas).To(BeNil())
+			})
+		})
+
 		When("the forecasted carbon intensity is 100 and max replicas is set to 10", func() {
 			var configs []carbonawarev1alpha1.CarbonIntensityConfig
 

--- a/controllers/max_replica_getter.go
+++ b/controllers/max_replica_getter.go
@@ -17,6 +17,11 @@ func getMaxReplicas(forecast *CarbonForecast, configs []carbonawarev1alpha1.Carb
 	} else {
 		ci := forecast.Value
 
+		// if the carbon intensity value is zero, the forecast entry has no measured value — treat as missing data
+		if ci == 0 {
+			return nil, fmt.Errorf("carbon intensity value is zero or missing")
+		}
+
 		// sort to ensure that configured carbon intensity thresholds are sorted is in ascending order to better evaluate lower and upper bounds
 		sort.Slice(configs, func(i, j int) bool {
 			return configs[i].CarbonIntensityThreshold < configs[j].CarbonIntensityThreshold


### PR DESCRIPTION
Fixes #14

## Problem

When a ConfigMap entry for the current time window has no `value` field, Go's JSON unmarshalling sets the `float64` to `0.0`. In `getMaxReplicas`, the first bucket checks `ci > 0` (lowerBound of the first tier is always 0), which is `false`, so no tier matches and the function silently falls through to return the last configured tier — typically the minimum replica count.

This was observed with a real carbon intensity data source that only stores measured past values and leaves upcoming 5-minute slots without a `value` field.

## Fix

Add an explicit zero-check in `getMaxReplicas` before the threshold loop. When `ci == 0`, return `nil, error` so the reconciler treats it as missing data and falls back to `ecoModeOff.maxReplicas`, consistent with the nil-forecast and fetch-error paths.

## Changes

- `controllers/max_replica_getter.go`: return error when `forecast.Value == 0`
- `controllers/carbonawarekedascaler_controller_test.go`: add regression test for the zero-value case

## Testing

`make test` — 23/23 specs pass.